### PR TITLE
The link in the documentation to the license was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ After running the program, the `./output` directory might look something like th
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://opensource.org/license/MIT) file for details.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MIT License link in the README to point to the official external page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->